### PR TITLE
use last point for x/y when closing a path

### DIFF
--- a/frontend/js/app_svgreader.js
+++ b/frontend/js/app_svgreader.js
@@ -812,21 +812,16 @@ SVGReader = {
           }
           break;
         case 'Z':  // closepath
+        case 'z':
           // loop and finalize subpath
           if ( subpath.length > 0) {
             subpath.push(subpath[0]);  // close
             node.path.push(subpath);
+            x = subpath[subpath.length-1][0];
+            y = subpath[subpath.length-1][1];
             subpath = [];
-          }      
+          }
           break;
-        case 'z':  // closepath
-          // loop and finalize subpath
-          if ( subpath.length > 0) {
-            subpath.push(subpath[0]);  // close
-            node.path.push(subpath);
-            subpath = [];
-          }  
-          break          
         case 'L':  // lineto absolute
           while (nextIsNum()) {
             x = getNext();


### PR DESCRIPTION
When closing a path and the next command is a relative move, it is important that the last point be used otherwise things won't line up as expected.

Before: 
![Screen shot 2013-02-14 at 2 15 11 PM](https://f.cloud.github.com/assets/46673/158574/c69c5d12-76eb-11e2-9c99-bde8da4bfa62.png)

After:
![Screen shot 2013-02-14 at 2 18 30 PM](https://f.cloud.github.com/assets/46673/158581/27d0a35e-76ec-11e2-9851-6909a3f59543.png)

Using this svg file: 

``` svg

<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!-- Created with Inkscape (http://www.inkscape.org/) -->

<svg
   xmlns:dc="http://purl.org/dc/elements/1.1/"
   xmlns:cc="http://creativecommons.org/ns#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:svg="http://www.w3.org/2000/svg"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
   width="744.09448819"
   height="1052.3622047"
   id="svg2"
   version="1.1"
   inkscape:version="0.48.4 r9939"
   sodipodi:docname="hi.svg">

  <g
     inkscape:label="Layer 1"
     inkscape:groupmode="layer"
     id="layer1">

    <g
       style="font-size:487.00503539999999703px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:Clean;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none"
       id="text3784">
      <path
         id="path3794"
         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
         d="m 192.46875,280 c -4.45894,-6.3e-4 -8.89066,1.83469 -12.04361,4.98764 -3.15295,3.15295 -4.98827,7.58467 -4.98764,12.04361 l 0,370.03125 c -6.3e-4,4.45894 1.83469,8.89066 4.98764,12.04361 3.15295,3.15295 7.58467,4.98827 12.04361,4.98764 l 44,0 c 4.45894,6.3e-4 8.89066,-1.83469 12.04361,-4.98764 3.15295,-3.15295 4.98827,-7.58467 4.98764,-12.04361 l 0,-150.53125 c -8e-5,-23.02808 5.67388,-38.7149 16.03125,-50.15625 10.34404,-11.42649 23.28027,-16.99981 43.28125,-17 16.0443,1.9e-4 24.38443,4.05972 30.8125,12.25 6.40643,8.16334 11.1248,23.10374 11.125,46.09375 l 0,159.34375 c -6.3e-4,4.45894 1.83469,8.89066 4.98764,12.04361 3.15295,3.15295 7.58467,4.98827 12.04361,4.98764 l 43.75,0 c 4.45894,6.3e-4 8.89066,-1.83469 12.04361,-4.98764 3.15295,-3.15295 4.98827,-7.58467 4.98764,-12.04361 l 0,-160.75 C 432.56221,467.13401 424.28141,435.04851 405.125,412 c -0.009,-0.0115 -0.0218,-0.0198 -0.0312,-0.0312 -19.15288,-23.19123 -48.42465,-34.6872 -82.53125,-34.6875 -20.96451,3.1e-4 -40.48788,4.5803 -57.5,14.03125 -0.0209,0.0104 -0.0417,0.0208 -0.0625,0.0312 -3.98516,2.23891 -7.79787,4.77842 -11.5,7.53125 l 0,-101.84375 c 6.3e-4,-4.45894 -1.83469,-8.89066 -4.98764,-12.04361 -3.15295,-3.15295 -7.58467,-4.98827 -12.04361,-4.98764 z m 310.8125,0 c -4.45894,-6.3e-4 -8.89066,1.83469 -12.04361,4.98764 -3.15295,3.15295 -4.98827,7.58467 -4.98764,12.04361 l 0,55.40625 c -6.3e-4,4.45894 1.83469,8.89066 4.98764,12.04361 3.15295,3.15295 7.58467,4.98827 12.04361,4.98764 l 43.75,0 c 4.45894,6.3e-4 8.89066,-1.83469 12.04361,-4.98764 3.15295,-3.15295 4.98827,-7.58467 4.98764,-12.04361 l 0,-55.40625 c 6.3e-4,-4.45894 -1.83469,-8.89066 -4.98764,-12.04361 -3.15295,-3.15295 -7.58467,-4.98827 -12.04361,-4.98764 z m 0,103.6875 c -4.45894,-6.3e-4 -8.89066,1.83469 -12.04361,4.98764 -3.15295,3.15295 -4.98827,7.58467 -4.98764,12.04361 l 0,266.34375 c -6.3e-4,4.45894 1.83469,8.89066 4.98764,12.04361 3.15295,3.15295 7.58467,4.98827 12.04361,4.98764 l 43.75,0 c 4.45894,6.3e-4 8.89066,-1.83469 12.04361,-4.98764 3.15295,-3.15295 4.98827,-7.58467 4.98764,-12.04361 l 0,-266.34375 c 6.3e-4,-4.45894 -1.83469,-8.89066 -4.98764,-12.04361 -3.15295,-3.15295 -7.58467,-4.98827 -12.04361,-4.98764 z" />
    </g>
  </g>
</svg>

```

This also combines the `z` and `Z` cases
