### PR TITLE
hanger when importing certain SVGs

### DIFF
--- a/backend/filereaders/svg_path_reader.py
+++ b/backend/filereaders/svg_path_reader.py
@@ -310,6 +310,13 @@ class SVGPathReader:
             # protect from deep recursion cases
             # max 2**18 = 262144 segments
             return
+        elif level == 0:
+            if (x1 == x2 and y1 == y2 and x2 == x3 and y2 == y3) or \
+               (x2 == x3 and y2 == y3 and x3 == x4 and y3 == y4):
+                # the tolerance would never reached, but it's a straight line
+                #subpath.append([x1, y1]) # probably not needed
+                subpath.append([x4, y4])
+                return
         
         # Calculate all the mid-points of the line segments
         x12   = (x1 + x2) / 2.0

--- a/frontend/app.html
+++ b/frontend/app.html
@@ -13,7 +13,6 @@
 <script src="/js/jquery.toastmessage.js"></script>
 <script src="/js/jquery.hotkeys.js"></script>
 <script src="/js/settings.js"></script>
-<script src="/js/app_svgreader.js"></script>
 <script src="/js/app_datahandler.js"></script>
 <script src="/js/app_canvas.js"></script>
 <script src="/js/app.js"></script>


### PR DESCRIPTION
When you try to import this file: http://log2.ch/misc/t-rex-1.svg LasaurApp will take forever.

The file is http://www.thingiverse.com/thing:9331 converted from DXF to SVG using Inkscape. (If there is a better approach to import this design I would be interested too - Lasersaur newbie here.)

The pull request fixes the problem, but maybe there is a way to fix the tolerance calculation instead? I didn't understand the math of it yet.