### PR TITLE
case-insensitive lasertags + more passes

### DIFF
--- a/backend/filereaders/svg_tag_reader.py
+++ b/backend/filereaders/svg_tag_reader.py
@@ -37,7 +37,7 @@ class SVGTagReader:
             'text': True  # text is special, see read_tag func
         }
 
-        self.re_findall_lasertags = re.compile('=pass([0-9]+):([0-9]*)(mm\/min)?:([0-9]*)(%)?(:#[a-fA-F0-9]{6})?(:#[a-fA-F0-9]{6})?(:#[a-fA-F0-9]{6})?(:#[a-fA-F0-9]{6})?(:#[a-fA-F0-9]{6})?(:#[a-fA-F0-9]{6})?=').findall
+        self.re_findall_lasertags = re.compile('=pass([0-9]+):([0-9]*)(mm\/min)?:([0-9]*)(%)?(:#[a-f0-9]{6})?(:#[a-f0-9]{6})?(:#[a-f0-9]{6})?(:#[a-f0-9]{6})?(:#[a-f0-9]{6})?(:#[a-f0-9]{6})?=').findall
 
 
     def read_tag(self, tag, node):
@@ -227,7 +227,7 @@ class SVGTagReader:
         # # search one level deep
         for child in tag:
             text_accum.append(child.text or '')
-        text_accum = ' '.join(text_accum)
+        text_accum = ' '.join(text_accum).lower()
         matches = self.re_findall_lasertags(text_accum)
         # Something like: =pass12:2550:100%:#fff000:#ababab:#ccc999=
         # Results in: [('12', '2550', '', '100', '%', ':#fff000', ':#ababab', ':#ccc999', '', '', '')]

--- a/frontend/js/app_laserjobs.js
+++ b/frontend/js/app_laserjobs.js
@@ -1,7 +1,7 @@
 
 
 var minNumPassWidgets = 3;
-var maxNumPassWidgets = 32;
+var maxNumPassWidgets = 256;
 var preview_canvas_obj = null;
 
 


### PR DESCRIPTION
Allow uppercase lasertags. It's easy to workaround this, but only once you figure out what the problem is...

And increased the max. number of passes (useful for power calibration files, and I see no reason for the low limit).