### PR TITLE
Optionally enable internal pull-up resistors for limits and interlocks.

### DIFF
--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -79,9 +79,9 @@
 #else
   #define LIMITS_OVERWRITE_DDR  DDRD
   #define LIMITS_OVERWRITE_PORT PORTD
-  #define LIMITS_OVERWRITE_BIT  7  
+  #define LIMITS_OVERWRITE_BIT  7
 #endif
-  
+
 #define LIMIT_DDR               DDRC
 #define LIMIT_PORT              PORTC
 #define LIMIT_PIN               PINC
@@ -145,10 +145,10 @@
 
 // The temporal resolution of the acceleration management subsystem. Higher number give smoother
 // acceleration but may impact performance.
-// NOTE: Increasing this parameter will help any resolution related issues, especially with machines 
-// requiring very high accelerations and/or very fast feedrates. In general, this will reduce the 
+// NOTE: Increasing this parameter will help any resolution related issues, especially with machines
+// requiring very high accelerations and/or very fast feedrates. In general, this will reduce the
 // error between how the planner plans the motions and how the stepper program actually performs them.
-// However, at some point, the resolution can be high enough, where the errors related to numerical 
+// However, at some point, the resolution can be high enough, where the errors related to numerical
 // round-off can be great enough to cause problems and/or it's too fast for the Arduino. The correct
 // value for this parameter is machine dependent, so it's advised to set this only as high as needed.
 // Approximate successful values can range from 30L to 100L or more.
@@ -165,7 +165,13 @@
 // never reach its target. This parameter should always be greater than zero.
 #define MINIMUM_STEPS_PER_MINUTE 1600U // (steps/min) - Integer value only
 // 1600 @ 32step_per_mm = 50mm/min
-  
+
+// Enable pull-up resistors on the limit sense lines. (normally high, active low)
+// #define SENSE_ENABLE_LIMIT_PULLUPS
+
+// Enable pull-up resistors on the door, chiller, and power sense lines (normally high, active low)
+// #define SENSE_ENABLE_INTERLOCK_PULLUPS
+
 
 #define X_AXIS 0
 #define Y_AXIS 1

--- a/firmware/src/sense_control.c
+++ b/firmware/src/sense_control.c
@@ -28,11 +28,17 @@
 void sense_init() {
   //// chiller, door, (power)
   SENSE_DDR &= ~(SENSE_MASK);  // set as input pins 
-  // SENSE_PORT |= SENSE_MASK;    //activate pull-up resistors 
+
+  #ifdef SENSE_ENABLE_INTERLOCK_PULLUPS
+    SENSE_PORT |= SENSE_MASK;    //activate pull-up resistors
+  #endif
   
   //// x1_lmit, x2_limit, y1_limit, y2_limit, z1_limit, z2_limit
   LIMIT_DDR &= ~(LIMIT_MASK);  // set as input pins
-  // LIMIT_PORT |= LIMIT_MASK;    //activate pull-up resistors   
+
+  #ifdef SENSE_ENABLE_LIMIT_PULLUPS
+    LIMIT_PORT |= LIMIT_MASK;    //activate pull-up resistors
+  #endif
 }
 
 


### PR DESCRIPTION
Handy for normally-high sense line systems.