### PR TITLE
fix high-power bursts during deceleration

### DIFF
--- a/firmware/src/stepper.c
+++ b/firmware/src/stepper.c
@@ -339,7 +339,11 @@ ISR(TIMER1_COMPA_vect) {
         // decelerating
         } else if (step_events_completed >= current_block->decelerate_after) {
           if ( acceleration_tick() ) {  // scheduled speed change
-            adjusted_rate -= current_block->rate_delta;
+            if (adjusted_rate > current_block->rate_delta) {
+              adjusted_rate -= current_block->rate_delta;
+            } else {
+              adjusted_rate = 0; // unsigned
+            }
             if (adjusted_rate < current_block->final_rate) {  // overshot
               adjusted_rate = current_block->final_rate;
             }


### PR DESCRIPTION
The problem was most visible when engraving small shapes at low power.

I haven't actually laser-tested this yet but used an arduino to monitor the PWM output of the firmware. I have triggered an oscilloscope on the large pulse width and was able to reproduce the glitches. Now they are gone and the duty stays below 5%.

The problem was already discussed and narrowed down by "jondale" and others in the google groups: https://groups.google.com/forum/#!topic/lasersaur/1i36ZNAvRFo (I'm not posting there because I don't like the idea of paying or asking for permission to submit a bugfix. Please consider opening the group up for everyone.)

An alternative fix would have been to just make the integer signed. But I'm not sure if the full range is used or not, and whether the other uint32_t in this file should be converted to signed, too.