### PR TITLE
frontend: show estimate of job duration

### DIFF
--- a/frontend/js/app_datahandler.js
+++ b/frontend/js/app_datahandler.js
@@ -135,6 +135,34 @@ DataHandler = {
     return glist.join('');
   },
 
+  getTimeEstimate : function() {
+    var pos_x = 0;
+    var pos_y = 0;
+    var estimatedTime = 0;
+    for (var i=0; i<this.passes.length; i++) {
+      var pass = this.passes[i];
+      var colors = pass['colors'];
+      var feedrate = this.mapConstrainFeedrate(pass['feedrate']);
+      for (var c=0; c<colors.length; c++) {
+        var color = colors[c];
+        var paths = this.paths_by_color[color];
+        for (var k=0; k<paths.length; k++) {
+          var path = paths[k];
+          if (path.length > 0) {
+            for (var vertex=0; vertex<path.length; vertex++) {
+              var x = path[vertex][0];
+              var y = path[vertex][1];
+              estimatedTime += Math.hypot(x-pos_x, y-pos_y)/feedrate*60;
+              pos_x = x;
+              pos_y = y;
+            }
+          }
+        }
+      }
+    }
+    return estimatedTime;
+  },
+
   getBboxGcode : function() {
     if (!('_all_' in this.stats_by_color)) {
       this.calculateBasicStats();

--- a/frontend/js/app_gcodereader.js
+++ b/frontend/js/app_gcodereader.js
@@ -160,68 +160,6 @@ GcodeReader = {
     this.exclude_colors = colors;
   },
 
-
-
-  ///////////////////////////////////////////////
-  // Stats
-
-  getStats : function() {
-    // Only adds up G1 lines, no arcs, which we should not need.
-    var cuttingPathLength = 0.0  // in mm
-    var estimatedTime = 0.0      // in min
-    var lastX = 0.0;
-    var lastY = 0.0;
-    var length = 0.0;
-    var currentF_seek = 0.0;
-    var currentF_feed = 0.0;
-    // var acc = 1800000; //mm/min^2, same as defined in LasaurGrbl config.h
-    var accelCompFactor = 1.0;
-
-    for (var color in this.moves_by_color) {
-      var moves = this.moves_by_color[color];
-      for (var i=0; i<moves.length; i++) {
-        var move = moves[i];
-        if (move.type == 0) {
-          if (move.F) {
-            // make sure we only get feed rate, no seek rate
-            currentF_seek = move.F;
-          }
-          lastX = move.X;
-          lastY = move.Y;
-        } else if (move.type == 1) {
-          if (move.F) {
-            // make sure we only get feed rate, no seek rate
-            currentF_feed = move.F;
-          }
-          length = Math.sqrt(Math.pow(move.X-lastX,2) + Math.pow(move.Y-lastY,2));
-          cuttingPathLength += length;
-          if (currentF_feed > 0.0 && length > 0.0) {
-            // very rough estimation
-            // var dist_for_accel_decel = 2*(currentF_feed*currentF_feed/(2*acc));
-            // var ratio = length/dist_for_accel_decel
-            // var feedrateComp = Math.max(0.1, Math.min(1.0, 0.25*ratio));          
-            // estimatedTime += length/(currentF_feed*feedrateComp);]
-
-            // accelCompFactor = 1.0;
-            // if (length < 1) {accelCompFactor = 1+currentF_feed/600.0;}
-            // else if (length < 5) {accelCompFactor = 1+currentF_feed/1000.0;}
-            // else if (length < 10) {accelCompFactor = 1+currentF_feed/2000.0;}
-            // else if (length < 50) {accelCompFactor = 1+currentF_feed/3000.0;}
-            // else if (length < 100) {accelCompFactor = 1+currentF_feed/6000.0;}
-            // accelCompFactor = 1+currentF_feed/(length*60)
-            // estimatedTime += (length/currentF_feed)*accelCompFactor*2.0;
-            // alert(length/currentF_feed + "->" + estimatedTime);
-            estimatedTime += (length/currentF_feed);
-          }
-          lastX = move.X;
-          lastY = move.Y;
-        }
-      }
-    }
-    estimatedTime *= 5.0;
-    return {'cuttingPathLength':cuttingPathLength, 'estimatedTime':estimatedTime};
-  },
-
   bboxClear : function() {
     this.bbox = [99999,99999,0,0];
   },

--- a/frontend/js/app_laserjobs.js
+++ b/frontend/js/app_laserjobs.js
@@ -22,6 +22,24 @@ function load_into_job_widget(name, jobdata) {
   $('html, body').animate({scrollTop:0}, 400);
 }
 
+function getDurationString(durationSeconds) {
+  var hours   = Math.floor(durationSeconds / 3600);
+  var minutes = Math.floor((durationSeconds - hours * 3600) / 60);
+  var seconds = Math.round(durationSeconds - hours * 3600 - minutes * 60);
+
+  var duration = '';
+  if (seconds > 0 && hours == 0 && minutes < 15) {
+    duration = seconds + 's ' + duration;
+  }
+  if (minutes > 0) {
+    duration = minutes + 'min ' + duration;
+  }
+  if (hours > 0) {
+    duration = hours + 'h ' + duration;
+  }
+
+  return duration;
+}
 
 function refresh_preview(reload_data, read_passes_widget) {
   if (reload_data === true) {
@@ -32,17 +50,12 @@ function refresh_preview(reload_data, read_passes_widget) {
   }
   DataHandler.draw(preview_canvas_obj, app_settings.to_canvas_scale);
   DataHandler.draw_bboxes(preview_canvas_obj, app_settings.to_canvas_scale);
-  // var stats = GcodeReader.getStats();
-  // var length = stats.cuttingPathLength;
-  // var duration = stats.estimatedTime;
-  // $('#previe_stats').html("~" + duration.toFixed(1) + "min");
-  // $().uxmessage('notice', "Total cutting path is: " + (length/1000.0).toFixed(2) +
-  //               "m. Estimated Time: " + duration.toFixed(1) + "min");
   var total_length = DataHandler.getJobPathLength();
+  var total_duration = DataHandler.getTimeEstimate() * 1.10;
   if (total_length > 0) {
-    $('#stats_after_name').html('length: '+(total_length/1000).toFixed(1)+'m');
+    $('#stats_after_name').html(getDurationString(total_duration)+' (length: '+(total_length/1000).toFixed(1)+'m)');
   } else {
-    $('#stats_after_name').html('');
+    $('#stats_after_name').html('select a color');
   }
 }
 
@@ -251,6 +264,14 @@ function addPasses(num) {
       }
       refresh_preview(true, true);
     });
+    pass_elem.find('.feedrate').on('input', (function(e){
+      // estimate no longer valid
+      $('#stats_after_name').html('');
+    }));
+     pass_elem.find('.feedrate').on('change', (function(e){
+      // update time estimate
+      refresh_preview(true, true);
+    }));
   }
   $('#passes_container').show();
 }


### PR DESCRIPTION
New time estimate code, similar to gcode generation code. Acceleration is ignored for now, we simply add 10%. The old (inactive and commented-out) time estimate code is removed.

I was a bit worried that performance might not be good enough (it can be optimized if required), but when I tested it with a large-ish job (which took 20s to import), the update delay when changing the feeddrate was quite reasonable (below one seconds).